### PR TITLE
Add ROS build artifacts to .git gnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .vscode/**/*
+**/build/**/*
+**/install/**/*
+**/log/**/*


### PR DESCRIPTION
When ROS packages built using colcon the generated artifacts should not be tracked

- build
- log
- 'install

The generated artifacts has been added to the .gitignore file